### PR TITLE
added dedupe with tests

### DIFF
--- a/src/dedupe.test.ts
+++ b/src/dedupe.test.ts
@@ -1,0 +1,85 @@
+import test from 'ava'
+import dedupe from './dedupe.js'
+
+// Setup
+
+const options = {}
+const state = {
+  context: [],
+  value: {},
+}
+
+// Tests
+
+test('should remove duplicates in a flat array of strings', (t) => {
+  const value = ['1', '1', '1', '2', '3']
+  const expected = ['1', '2', '3']
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should remove duplicates in arrays with different simple data types', (t) => {
+  const value = ['1', '1', '1', '2', '3', 1, 2, 2, 2, 3]
+  const expected = ['1', '2', '3', 1, 2, 3]
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should remove duplicates in arrays with booleans', (t) => {
+  const value = ['1', '1', '1', '2', '3', true, true, null, null, false, false]
+  const expected = ['1', '2', '3', true, null, false]
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should remove objects with the same values and structures', (t) => {
+  const value = [{ value: '1' }, { value: '1' }, { value: '2' }]
+  const expected = [{ value: '1' }, { value: '2' }]
+
+  const ret = dedupe({ path: 'value' }, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should remove objects with nested values', (t) => {
+  const value = [
+    { container: { value: '1' } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+    { container: { value: '2' } },
+    { container: { value: '3' } },
+  ]
+  const expected = [
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+    { container: { value: '3' } },
+  ]
+
+  const ret = dedupe({ path: 'container.value' }, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should return empty array if array is empty', (t) => {
+  const value: [] = []
+  const expected: [] = []
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should return data if data is not an array', (t) => {
+  const value = { test: 'whatever' }
+  const expected = { test: 'whatever' }
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})

--- a/src/dedupe.test.ts
+++ b/src/dedupe.test.ts
@@ -47,6 +47,24 @@ test('should remove objects with the same values and structures', (t) => {
   t.deepEqual(ret, expected)
 })
 
+test('should return empty array if array is empty', (t) => {
+  const value: [] = []
+  const expected: [] = []
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should return data if data is not an array', (t) => {
+  const value = { test: 'whatever' }
+  const expected = { test: 'whatever' }
+
+  const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
 test('should remove objects with nested values', (t) => {
   const value = [
     { container: { value: '1' } },

--- a/src/dedupe.test.ts
+++ b/src/dedupe.test.ts
@@ -66,20 +66,75 @@ test('should remove objects with nested values', (t) => {
   t.deepEqual(ret, expected)
 })
 
-test('should return empty array if array is empty', (t) => {
-  const value: [] = []
-  const expected: [] = []
+test('should remove duplicates of simple data when no path specficied', (t) => {
+  const value = [
+    1,
+    1,
+    2,
+    2,
+    3,
+    { container: { value: '1' } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+    { container: { value: '2' } },
+    { container: { value: '3' } },
+  ]
+  const expected = [
+    1,
+    2,
+    3,
+    { container: { value: '1' } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+    { container: { value: '2' } },
+    { container: { value: '3' } },
+  ]
 
   const ret = dedupe({}, options)(value, state)
 
   t.deepEqual(ret, expected)
 })
 
-test('should return data if data is not an array', (t) => {
-  const value = { test: 'whatever' }
-  const expected = { test: 'whatever' }
+test('should remove duplicates all instances of undefined', (t) => {
+  const value = [
+    1,
+    1,
+    undefined,
+    3,
+    { container: { value: '1' } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+  ]
+  const expected = [
+    1,
+    3,
+    { container: { value: '1' } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+  ]
 
   const ret = dedupe({}, options)(value, state)
+
+  t.deepEqual(ret, expected)
+})
+
+test('should remove all items where value of path becomes undefined', (t) => {
+  const value = [
+    1,
+    1,
+    undefined,
+    3,
+    { container: {} },
+    { container: { value: undefined } },
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+  ]
+  const expected = [
+    { container: { value: '1' } },
+    { container: { value: '2' } },
+  ]
+
+  const ret = dedupe({ path: 'container.value' }, options)(value, state)
 
   t.deepEqual(ret, expected)
 })

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -16,7 +16,9 @@ const transformer: Transformer = function removeDuplicates(
       ? data
       : data.filter((element, index) => {
           const value = getter(element)
-          return data.findIndex((item) => getter(item) === value) === index
+          return value === undefined
+            ? false
+            : data.findIndex((item) => getter(item) === value) === index
         })
   }
 }

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -1,0 +1,24 @@
+import type { Transformer } from 'integreat'
+import { isArray, isObject } from './utils/is.js'
+import { getPathOrDefault } from './utils/getters.js'
+
+export interface Props extends Record<string, unknown> {
+  path?: string
+}
+
+const transformer: Transformer = function removeDuplicates(
+  { path = '.' }: Props,
+  _options
+) {
+  const getter = getPathOrDefault(path)
+  return (data: unknown) => {
+    return !isArray(data)
+      ? data
+      : data.filter((element, index) => {
+          const value = getter(element)
+          return data.findIndex((item) => getter(item) === value) === index
+        })
+  }
+}
+
+export default transformer

--- a/src/utils/getters.ts
+++ b/src/utils/getters.ts
@@ -7,12 +7,12 @@ export function getPathOrData(path?: string) {
 export function getPathOrDefault(
   path?: string,
   def?: unknown,
-  predicate = (data: unknown) => !!data
+  predicate = (data: unknown) => data !== undefined
 ) {
   if (typeof path !== 'string') {
     return () => def
   }
-  const getter = mapTransform(path)
+  const getter = mapTransform(path, { nonvalues: [undefined] })
 
   return function getOrDefault(data: unknown) {
     const value = getter(data)


### PR DESCRIPTION
Created dedupe transformer that removes duplicates from an array.  It accepts "path" as an optional argument.  This allows the removal of duplicates based on an embedded value inside objects in the array.  It also handles removing duplicates that are simple types, from the arrays.